### PR TITLE
ControlPlane, DataPlaneのk8sバージョンを指定できるよう引数versionを変数化

### DIFF
--- a/eks_cluster.tf
+++ b/eks_cluster.tf
@@ -32,6 +32,7 @@ resource "aws_iam_role_policy_attachment" "aws_eks_service_policy" {
 # == Cluster ==============================================
 resource "aws_eks_cluster" "main" {
   name     = "eks-deploy_cluster"
+  version  = var.eks_cluster_version
   role_arn = aws_iam_role.eks_cluster.arn
   vpc_config {
     security_group_ids = [aws_security_group.eks_cluster.id, aws_security_group.eks_nodes.id]

--- a/node_groups.tf
+++ b/node_groups.tf
@@ -66,6 +66,7 @@ EOF
 resource "aws_eks_node_group" "main" {
   cluster_name    = aws_eks_cluster.main.name
   node_group_name = "eks-deploy-private"
+  version         = var.eks_worker_version
   node_role_arn   = aws_iam_role.eks_nodes.arn
   subnet_ids      = aws_subnet.private-subnet[*].id
   ami_type        = var.ami_type
@@ -89,6 +90,7 @@ resource "aws_eks_node_group" "main" {
 }
 
 # Nodes in public subnet
+/*
 resource "aws_eks_node_group" "public" {
   cluster_name    = aws_eks_cluster.main.name
   node_group_name = "eks-deploy-public"
@@ -113,4 +115,5 @@ resource "aws_eks_node_group" "public" {
     aws_iam_role_policy_attachment.ec2_read_only,
   ]
 }
+*/
 # =========================================================

--- a/variables.tf
+++ b/variables.tf
@@ -9,6 +9,14 @@ variable "availability_zone" {
   default = ["ap-northeast-1a", "ap-northeast-1c", "ap-northeast-1d"]
 }
 
+variable "eks_cluster_version" {
+  default = "1.18"
+}
+
+variable "eks_worker_version" {
+  default = "1.18"
+}
+
 # == WorkerNode Instance Parameters =======================
 variable "ami_type" {
   default = "AL2_x86_64"


### PR DESCRIPTION
変更点
- aws_eks_cluster, aws_eks_node_group に引数versionを追加
- variable.tf に eks_cluster_version, eks_worker_version を追加
- aws_eks_node_group.public をコメントアウト